### PR TITLE
feat(memory): retention policies and compaction engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "acu-memory"
+version = "0.1.0"
+dependencies = [
+ "acu-agent",
+ "chrono",
+ "serde",
+ "thiserror",
+ "toml",
+ "uuid",
+]
+
+[[package]]
 name = "aei-framework"
 version = "0.1.0"
 source = "git+https://github.com/SynarionTechnologies/aei-framework?branch=main#7203614bf0a0944f835c0351a3f5706040e827b0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "acu-cli",
     "acu-agent",
     "acu-adapters",
+    "acu-memory",
 ]
 resolver = "2"
 

--- a/acu-agent/src/events/memory.rs
+++ b/acu-agent/src/events/memory.rs
@@ -24,20 +24,32 @@ pub struct MemoryItemUpdated {
 pub struct MemoryItemDeleted {
     pub meta: EventMeta,
     pub item: String,
+    pub reason: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct MemoryItemArchived {
+    pub meta: EventMeta,
+    pub item: String,
+    pub destination: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct MemoryCompacted {
     pub meta: EventMeta,
+    pub store: String,
+    pub freed_space_bytes: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct MemoryRetentionPolicyChanged {
     pub meta: EventMeta,
-    pub policy: String,
+    pub old: String,
+    pub new: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct MemoryReindexed {
     pub meta: EventMeta,
 }
+

--- a/acu-agent/src/events/mod.rs
+++ b/acu-agent/src/events/mod.rs
@@ -86,6 +86,7 @@ pub enum AcuEvent {
     MemoryItemAccessed(memory::MemoryItemAccessed),
     MemoryItemUpdated(memory::MemoryItemUpdated),
     MemoryItemDeleted(memory::MemoryItemDeleted),
+    MemoryItemArchived(memory::MemoryItemArchived),
     MemoryCompacted(memory::MemoryCompacted),
     MemoryRetentionPolicyChanged(memory::MemoryRetentionPolicyChanged),
     MemoryReindexed(memory::MemoryReindexed),
@@ -153,6 +154,7 @@ impl AcuEvent {
             AcuEvent::MemoryItemAccessed(_) => "MemoryItemAccessed",
             AcuEvent::MemoryItemUpdated(_) => "MemoryItemUpdated",
             AcuEvent::MemoryItemDeleted(_) => "MemoryItemDeleted",
+            AcuEvent::MemoryItemArchived(_) => "MemoryItemArchived",
             AcuEvent::MemoryCompacted(_) => "MemoryCompacted",
             AcuEvent::MemoryRetentionPolicyChanged(_) => "MemoryRetentionPolicyChanged",
             AcuEvent::MemoryReindexed(_) => "MemoryReindexed",
@@ -183,3 +185,4 @@ impl AcuEvent {
         }
     }
 }
+

--- a/acu-memory/Cargo.toml
+++ b/acu-memory/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "acu-memory"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"
+chrono = { version = "0.4", features = ["serde", "clock"] }
+uuid = { version = "1", features = ["v4"] }
+thiserror = "1"
+acu-agent = { path = "../acu-agent" }

--- a/acu-memory/src/config.rs
+++ b/acu-memory/src/config.rs
@@ -1,0 +1,47 @@
+use serde::Deserialize;
+
+/// Weights for computing the retention score of a memory item.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct RetentionWeights {
+    pub recency: f32,
+    pub reward: f32,
+    #[serde(rename = "reference_count")]
+    pub reference_count: f32,
+    pub uniqueness: f32,
+}
+
+/// Retention policy configuration loaded from TOML.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct RetentionConfig {
+    pub episodic_ttl_days: i64,
+    pub tool_logs_ttl_days: i64,
+    pub purge_threshold: f32,
+    pub weights: RetentionWeights,
+}
+
+impl RetentionConfig {
+    /// Parses the retention configuration from a TOML string.
+    pub fn from_toml_str(toml_str: &str) -> Result<Self, toml::de::Error> {
+        #[derive(Deserialize)]
+        struct Root {
+            memory: MemorySection,
+        }
+        #[derive(Deserialize)]
+        struct MemorySection {
+            retention: RetentionConfig,
+        }
+        let root: Root = toml::from_str(toml_str)?;
+        Ok(root.memory.retention)
+    }
+
+    /// Returns the TTL in days for the given channel.
+    pub fn ttl_for_channel(&self, channel: &super::MemoryChannel) -> i64 {
+        match channel {
+            super::MemoryChannel::Episodic => self.episodic_ttl_days,
+            super::MemoryChannel::ToolLogs => self.tool_logs_ttl_days,
+            // default TTL for channels without explicit configuration
+            _ => 365,
+        }
+    }
+}
+

--- a/acu-memory/src/engine.rs
+++ b/acu-memory/src/engine.rs
@@ -1,0 +1,152 @@
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+use acu_agent::events::{AcuEvent, EventMeta, memory::{MemoryCompacted, MemoryItemArchived, MemoryItemDeleted}};
+
+use crate::config::RetentionConfig;
+
+/// Channel of memory item.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MemoryChannel {
+    Episodic,
+    ToolLogs,
+    Semantic,
+    Knowledge,
+}
+
+/// Metadata describing a memory item for retention evaluation.
+#[derive(Debug, Clone)]
+pub struct MemoryItem {
+    pub id: String,
+    pub channel: MemoryChannel,
+    pub created_at: DateTime<Utc>,
+    pub last_accessed_at: DateTime<Utc>,
+    pub reward: f32,
+    pub reference_count: u32,
+    pub uniqueness: f32,
+}
+
+/// Actions decided by the retention engine.
+#[derive(Debug, Default)]
+pub struct RetentionReport {
+    pub deleted: usize,
+    pub archived: usize,
+    pub kept: usize,
+}
+
+/// Report from compaction phase.
+#[derive(Debug, Default)]
+pub struct CompactionReport {
+    pub freed_space_bytes: u64,
+}
+
+/// Error type for the retention engine.
+#[derive(thiserror::Error, Debug)]
+pub enum EngineError {
+    #[error("store error: {0}")]
+    Store(String),
+}
+
+/// Abstraction over underlying memory store.
+pub trait MemoryStore {
+    fn list_items(&self) -> Vec<MemoryItem>;
+    fn delete(&mut self, id: &str) -> Result<(), String>;
+    fn archive(&mut self, id: &str) -> Result<(), String>;
+    fn compact(&mut self) -> Result<u64, String>;
+}
+
+/// Engine applying retention policies.
+pub trait RetentionEngine {
+    fn apply_policies(&mut self) -> Result<RetentionReport, EngineError>;
+    fn compact(&mut self) -> Result<CompactionReport, EngineError>;
+    fn events(&self) -> &[AcuEvent];
+}
+
+/// Default implementation of the retention engine.
+pub struct DefaultRetentionEngine<S: MemoryStore> {
+    config: RetentionConfig,
+    store: S,
+    events: Vec<AcuEvent>,
+}
+
+impl<S: MemoryStore> DefaultRetentionEngine<S> {
+    pub fn new(config: RetentionConfig, store: S) -> Self {
+        Self { config, store, events: Vec::new() }
+    }
+
+    fn new_meta() -> EventMeta {
+        EventMeta::new(Uuid::new_v4(), Uuid::new_v4(), Utc::now(), None)
+    }
+
+    fn score(&self, item: &MemoryItem, now: DateTime<Utc>) -> f32 {
+        let ttl_days = self.config.ttl_for_channel(&item.channel) as f32;
+        let age_days = (now - item.last_accessed_at).num_days() as f32;
+        let recency_factor = (-(age_days / ttl_days.max(1.0))).exp();
+        let normalized_reward = item.reward.clamp(0.0, 1.0);
+        let normalized_ref_count = (item.reference_count as f32
+            / (1.0 + item.reference_count as f32))
+            .clamp(0.0, 1.0);
+        let uniqueness_factor = item.uniqueness.clamp(0.0, 1.0);
+        let w = &self.config.weights;
+        let score = w.recency * recency_factor
+            + w.reward * normalized_reward
+            + w.reference_count * normalized_ref_count
+            + w.uniqueness * uniqueness_factor;
+        score.clamp(0.0, 1.0)
+    }
+}
+
+impl<S: MemoryStore> RetentionEngine for DefaultRetentionEngine<S> {
+    fn apply_policies(&mut self) -> Result<RetentionReport, EngineError> {
+        let now = Utc::now();
+        let mut report = RetentionReport::default();
+        let items = self.store.list_items();
+        for item in items {
+            let ttl = self.config.ttl_for_channel(&item.channel);
+            let age_days = (now - item.created_at).num_days();
+            if age_days <= ttl {
+                report.kept += 1;
+                continue;
+            }
+            let score = self.score(&item, now);
+            if score < self.config.purge_threshold {
+                self.store
+                    .delete(&item.id)
+                    .map_err(EngineError::Store)?;
+                self.events.push(AcuEvent::MemoryItemDeleted(MemoryItemDeleted {
+                    meta: Self::new_meta(),
+                    item: item.id.clone(),
+                    reason: "expired".into(),
+                }));
+                report.deleted += 1;
+            } else {
+                self.store
+                    .archive(&item.id)
+                    .map_err(EngineError::Store)?;
+                self.events.push(AcuEvent::MemoryItemArchived(MemoryItemArchived {
+                    meta: Self::new_meta(),
+                    item: item.id.clone(),
+                    destination: "cold".into(),
+                }));
+                report.archived += 1;
+            }
+        }
+        Ok(report)
+    }
+
+    fn compact(&mut self) -> Result<CompactionReport, EngineError> {
+        let freed = self.store.compact().map_err(EngineError::Store)?;
+        self.events.push(AcuEvent::MemoryCompacted(MemoryCompacted {
+            meta: Self::new_meta(),
+            store: "kv".into(),
+            freed_space_bytes: freed,
+        }));
+        Ok(CompactionReport { freed_space_bytes: freed })
+    }
+
+    fn events(&self) -> &[AcuEvent] {
+        &self.events
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/acu-memory/src/engine/tests.rs
+++ b/acu-memory/src/engine/tests.rs
@@ -1,0 +1,88 @@
+use super::*;
+use crate::config::{RetentionConfig, RetentionWeights};
+use chrono::Utc;
+
+struct TestStore {
+    items: Vec<MemoryItem>,
+}
+
+impl MemoryStore for TestStore {
+    fn list_items(&self) -> Vec<MemoryItem> {
+        self.items.clone()
+    }
+    fn delete(&mut self, id: &str) -> Result<(), String> {
+        self.items.retain(|i| i.id != id);
+        Ok(())
+    }
+    fn archive(&mut self, id: &str) -> Result<(), String> {
+        self.items.retain(|i| i.id != id);
+        Ok(())
+    }
+    fn compact(&mut self) -> Result<u64, String> {
+        Ok(42)
+    }
+}
+
+fn sample_config() -> RetentionConfig {
+    RetentionConfig {
+        episodic_ttl_days: 60,
+        tool_logs_ttl_days: 14,
+        purge_threshold: 0.2,
+        weights: RetentionWeights {
+            recency: 0.5,
+            reward: 0.3,
+            reference_count: 0.1,
+            uniqueness: 0.1,
+        },
+    }
+}
+
+fn sample_item(id: &str, days_old: i64, score: f32) -> MemoryItem {
+    let now = Utc::now();
+    MemoryItem {
+        id: id.into(),
+        channel: MemoryChannel::Episodic,
+        created_at: now - chrono::Duration::days(days_old),
+        last_accessed_at: now - chrono::Duration::days(days_old),
+        reward: score,
+        reference_count: 0,
+        uniqueness: 0.5,
+    }
+}
+
+#[test]
+fn computes_score_within_bounds() {
+    let cfg = sample_config();
+    let store = TestStore { items: vec![] };
+    let engine = DefaultRetentionEngine::new(cfg, store);
+    let item = sample_item("1", 10, 0.5);
+    let s = engine.score(&item, Utc::now());
+    assert!(s >= 0.0 && s <= 1.0);
+}
+
+#[test]
+fn deletes_and_archives_items() {
+    let cfg = sample_config();
+    let items = vec![
+        sample_item("d", 100, 0.0), // delete
+        sample_item("a", 100, 1.0), // archive
+        sample_item("k", 5, 0.0),   // keep
+    ];
+    let store = TestStore { items };
+    let mut engine = DefaultRetentionEngine::new(cfg, store);
+    let report = engine.apply_policies().unwrap();
+    assert_eq!(report.deleted, 1);
+    assert_eq!(report.archived, 1);
+    assert_eq!(report.kept, 1);
+    assert_eq!(engine.events().len(), 2);
+}
+
+#[test]
+fn compaction_emits_event() {
+    let cfg = sample_config();
+    let store = TestStore { items: vec![] };
+    let mut engine = DefaultRetentionEngine::new(cfg, store);
+    let report = engine.compact().unwrap();
+    assert_eq!(report.freed_space_bytes, 42);
+    assert_eq!(engine.events().len(), 1);
+}

--- a/acu-memory/src/lib.rs
+++ b/acu-memory/src/lib.rs
@@ -1,0 +1,7 @@
+//! Memory retention and compaction engine.
+
+pub mod config;
+pub mod engine;
+
+pub use config::{RetentionConfig, RetentionWeights};
+pub use engine::{CompactionReport, DefaultRetentionEngine, EngineError, MemoryChannel, MemoryItem, RetentionEngine, RetentionReport};

--- a/docs/en/GLOSSARY.md
+++ b/docs/en/GLOSSARY.md
@@ -11,5 +11,7 @@
 - **Idempotency**: Property of producing the same result when executed multiple times.
 - **ULID/UUID**: Unique identifiers used for entities and events.
 - **Retention Policy**: Rules for keeping or deleting events over time.
+- **Compaction**: Physical cleanup of storage to reclaim space.
+- **Archiving**: Moving data from hot or warm storage to cold storage.
 - **Curiosity Policy**: Configures exploration behaviors of the agent.
 - **Safety Policy**: Guards against harmful actions.

--- a/docs/en/memory-retention.md
+++ b/docs/en/memory-retention.md
@@ -1,0 +1,39 @@
+# Memory Retention & Compaction
+
+ACU stores experiences in hot, warm and cold layers. Retention policies decide when items are kept, archived or deleted.
+
+## Retention score
+
+```
+score = w_recency * recency_factor
+      + w_reward * normalized_reward
+      + w_reference_count * normalized_ref_count
+      + w_uniqueness * uniqueness_factor
+```
+
+Items older than the channel TTL are removed when the score drops below `purge_threshold`; otherwise they are archived to the cold layer.
+
+## Configuration
+
+```toml
+[memory.retention]
+episodic_ttl_days = 60
+tool_logs_ttl_days = 14
+purge_threshold = 0.2
+
+[memory.retention.weights]
+recency = 0.5
+reward = 0.3
+reference_count = 0.1
+uniqueness = 0.1
+```
+
+## Manual execution
+
+```rust
+let engine = DefaultRetentionEngine::new(config, store);
+let report = engine.apply_policies()?;
+println!("Deleted: {}, Archived: {}", report.deleted, report.archived);
+```
+
+Compaction frees disk space and rotates snapshots after applying the policies.

--- a/docs/fr/GLOSSARY.md
+++ b/docs/fr/GLOSSARY.md
@@ -11,5 +11,7 @@
 - **Idempotence** : propriété produisant le même résultat lorsqu'exécuté plusieurs fois.
 - **ULID/UUID** : identifiants uniques utilisés pour entités et événements.
 - **Politique de rétention** : règles de conservation ou suppression des événements.
+- **Compaction** : nettoyage physique du stockage pour récupérer de l'espace.
+- **Archivage** : déplacement des données de la couche chaude ou tiède vers la couche froide.
 - **Politique de curiosité** : configure les comportements d'exploration de l'agent.
 - **Politique de sécurité** : protège contre les actions nuisibles.

--- a/docs/fr/retention-memoire.md
+++ b/docs/fr/retention-memoire.md
@@ -1,0 +1,39 @@
+# Rétention et compaction de la mémoire
+
+ACU stocke les expériences dans des couches chaude, tiède et froide. Les politiques de rétention décident quand les éléments sont conservés, archivés ou supprimés.
+
+## Score de rétention
+
+```
+score = w_recency * recency_factor
+      + w_reward * normalized_reward
+      + w_reference_count * normalized_ref_count
+      + w_uniqueness * uniqueness_factor
+```
+
+Les éléments plus anciens que le TTL du canal sont supprimés lorsque le score est inférieur à `purge_threshold`; sinon ils sont archivés vers la couche froide.
+
+## Configuration
+
+```toml
+[memory.retention]
+episodic_ttl_days = 60
+tool_logs_ttl_days = 14
+purge_threshold = 0.2
+
+[memory.retention.weights]
+recency = 0.5
+reward = 0.3
+reference_count = 0.1
+uniqueness = 0.1
+```
+
+## Exécution manuelle
+
+```rust
+let engine = DefaultRetentionEngine::new(config, store);
+let report = engine.apply_policies()?;
+println!("Supprimés: {}, Archivés: {}", report.deleted, report.archived);
+```
+
+La compaction libère de l'espace disque et fait tourner les instantanés après l'application des politiques.


### PR DESCRIPTION
## Summary
- implement configurable memory retention engine with scoring and TTL policies
- add compaction hook emitting MemoryCompacted events
- document retention policies and compaction in EN/FR

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689c465e5bc08321bf6499c05443af4f